### PR TITLE
Choose the last 1.0.x version available

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add this line to your `composer.json` file:
 ```json
 "require": {
     ...
-    "algolia/algolia-search-bundle": "1.0.1",
+    "algolia/algolia-search-bundle": "~1.0",
     ...
 }
 ```


### PR DESCRIPTION
because your 1.0.1 version does not work properly (the class "AlgoliaSearchEventSubscriber" wanted in the services.yml does not exist, but the AlgoliaSearchDoctrineEventSubscriber does)