### PR TITLE
Fix bug when using indexBy

### DIFF
--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -292,7 +292,7 @@ class Indexer
 
             if (count($value) > 0)
             {
-                $this->discoverEntity($value[0], $this->em);
+                $this->discoverEntity(reset($value), $this->em);
             }
 
             $value = array_map(function ($value) {


### PR DESCRIPTION
The index 0 does not exist in the collection/array if you use the indexBy doctrine feature (@ORM\OneToMany(targetEntity="SomeEntity", indexBy="someIndex")).
reset() should do the job as you only want to check what entity we're handling.