### PR TITLE
Fix return values of clear and reindex commands

### DIFF
--- a/Command/ClearCommand.php
+++ b/Command/ClearCommand.php
@@ -58,7 +58,17 @@ class ClearCommand extends ContainerAwareCommand
             $nIndexed += $this->clear($className);
         }
 
-        return $nIndexed;
+        switch ($nIndexed) {
+            case 0:
+                $output->writeln('No entity cleared');
+                break;
+            case 1:
+                $output->writeln('<info>1</info> entity cleared');
+                break;
+            default:
+                $output->writeln(sprintf('<info>%s</info> entities cleared', $nIndexed));
+                break;
+        }
     }
 
     public function clear($className)

--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -73,7 +73,17 @@ class ReindexCommand extends ContainerAwareCommand
             $this->getContainer()->get('algolia.indexer')->waitForAlgoliaTasks();
         }
 
-        return $nIndexed;
+        switch ($nIndexed) {
+            case 0:
+                $output->writeln('No entity indexed');
+                break;
+            case 1:
+                $output->writeln('<info>1</info> entity indexed');
+                break;
+            default:
+                $output->writeln(sprintf('<info>%s</info> entities indexed', $nIndexed));
+                break;
+        }
     }
 
     public function reIndex($className, $batchSize = 1000, $safe = true)


### PR DESCRIPTION
This PR is related to issue #28

Basically, the commands now always return 0 when no Exception occured. The number of entities index/cleared is now appearing in the output.

This is potentially a breaking change is you used the return value of the command in some way.

Let me know what you think about it.