### PR TITLE
Arbitrary addition of elements in Primary key

### DIFF
--- a/Mapping/Annotation/Id.php
+++ b/Mapping/Annotation/Id.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+class Id
+{
+}

--- a/Mapping/Description.php
+++ b/Mapping/Description.php
@@ -63,9 +63,10 @@ class Description
 
         return $this;
     }
-    public function mergeIdentifierAttributeNames(array $fields)
+
+    public function addIdentifierAttributeName($field)
     {
-        $this->identifierAttributeNames = array_unique(array_merge($this->identifierAttributeNames, $fields));
+        $this->identifierAttributeNames[] = $field;
 
         return $this;
     }
@@ -73,6 +74,11 @@ class Description
     public function getIdentifierFieldNames()
     {
         return $this->identifierAttributeNames;
+    }
+
+    public function hasIdentifierFieldNames()
+    {
+        return !empty($this->identifierAttributeNames);
     }
 
     public function addIndexIf(IndexIf $iif)

--- a/Mapping/Description.php
+++ b/Mapping/Description.php
@@ -9,6 +9,7 @@ class Description
     private $properties = [];
     private $methods = [];
     private $indexIfs = [];
+    private $identifierAttributeNames = [];
 
     public function __construct($class)
     {
@@ -59,6 +60,12 @@ class Description
     public function setIdentifierAttributeNames(array $fields)
     {
         $this->identifierAttributeNames = $fields;
+
+        return $this;
+    }
+    public function mergeIdentifierAttributeNames(array $fields)
+    {
+        $this->identifierAttributeNames = array_unique(array_merge($this->identifierAttributeNames, $fields));
 
         return $this;
     }

--- a/Mapping/Loader/AnnotationLoader.php
+++ b/Mapping/Loader/AnnotationLoader.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
 
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation\Id;
 use Doctrine\ORM\EntityManager;
 
 use Doctrine\Common\Annotations\AnnotationReader;
@@ -84,6 +85,9 @@ class AnnotationLoader implements LoaderInterface
 
                     $description->addProperty($field);
                 }
+                if ($annotation instanceof Id) {
+                    $description->mergeIdentifierAttributeNames(array($property->name));
+                }
             }
         }
         foreach ($refl->getMethods() as $meth) {
@@ -112,7 +116,7 @@ class AnnotationLoader implements LoaderInterface
         if (!$description->isEmpty()) {
 
             $meta = $em->getClassMetadata($class);
-            $description->setIdentifierAttributeNames($meta->getIdentifierFieldNames());
+            $description->mergeIdentifierAttributeNames($meta->getIdentifierFieldNames());
 
             // In case the user omitted defining the index, define it for him with default values
             if (null === $description->getIndex()) {

--- a/Mapping/Loader/AnnotationLoader.php
+++ b/Mapping/Loader/AnnotationLoader.php
@@ -86,7 +86,7 @@ class AnnotationLoader implements LoaderInterface
                     $description->addProperty($field);
                 }
                 if ($annotation instanceof Id) {
-                    $description->mergeIdentifierAttributeNames(array($property->name));
+                    $description->addIdentifierAttributeName($property->name);
                 }
             }
         }
@@ -116,7 +116,9 @@ class AnnotationLoader implements LoaderInterface
         if (!$description->isEmpty()) {
 
             $meta = $em->getClassMetadata($class);
-            $description->mergeIdentifierAttributeNames($meta->getIdentifierFieldNames());
+            if (!$description->hasIdentifierFieldNames()) {
+                $description->setIdentifierAttributeNames($meta->getIdentifierFieldNames());
+            }
 
             // In case the user omitted defining the index, define it for him with default values
             if (null === $description->getIndex()) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,15 +4,15 @@ parameters:
 
 services:
     algolia.indexer:
-        class: %algolia.indexer.class%
+        class: "%algolia.indexer.class%"
         calls:
             - [setEnvironment, ["%kernel.environment%"]]
             - [setApiSettings, ["%algolia.application_id%", "%algolia.api_key%"]]
     algolia.indexer_subscriber:
-        class: %algolia.indexer_subscriber.class%
+        class: "%algolia.indexer_subscriber.class%"
         arguments:
-            - @algolia.indexer
-            - %algolia.catch_log_exceptions%
-            - @?logger
+            - "@algolia.indexer"
+            - "%algolia.catch_log_exceptions%"
+            - "@?logger"
         tags:
             - {name: doctrine.event_subscriber}


### PR DESCRIPTION
Hi,

We use Gedmo to translate our entities. We have an issue : Index is rewritten when we change language. (Edition of fr_FR of our entity erase en_GB, for example) 

Solution : Make a composite primary key, including locale.

Problem : Gedmo have property "locale" which can contain locale, but this property is not a column, so Doctrine not considere this one as a Primary key with `@ORM\Id annotation`.

This pull request add an Id annotation in Algolia Bundle to handle this use case. Now I can add `@Algolia\Id` to my $locale property to make my composite primary key, Algolia side.

Have a nice day,
Gaël