### PR TITLE
Add index name prefix parameter

### DIFF
--- a/DependencyInjection/AlgoliaAlgoliaSearchExtension.php
+++ b/DependencyInjection/AlgoliaAlgoliaSearchExtension.php
@@ -29,6 +29,7 @@ class AlgoliaAlgoliaSearchExtension extends Extension
             $container->setParameter('algolia.api_key', $config['api_key']);
 
         $container->setParameter('algolia.catch_log_exceptions', $config['catch_log_exceptions']);
+        $container->setParameter('algolia.index_name_prefix', $config['index_name_prefix']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,9 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->scalarNode('api_key')
             ->end()
+            ->scalarNode('index_name_prefix')
+            ->defaultValue('')
+            ->end()
             ->booleanNode('catch_log_exceptions')
               ->defaultFalse()
             ->end();

--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -49,6 +49,10 @@ class Indexer
     // at service instanciation.
     private $environment;
 
+    // Stores the current index name prefix, this is injected by Symfo
+    // at service instanciation.
+    private $indexNamePrefix;
+
     /**
      * The algolia application_id and api_key.
      * Also injected for us by symfony from the config.
@@ -89,6 +93,14 @@ class Indexer
         $this->environment = $environment;
 
         return $this;
+    }
+
+    /**
+     * @param mixed $indexNamePrefix
+     */
+    public function setIndexNamePrefix($indexNamePrefix)
+    {
+        $this->indexNamePrefix = $indexNamePrefix;
     }
 
     public function setApiSettings($application_id, $api_key)
@@ -145,7 +157,7 @@ class Indexer
             if ($reflClass->isAbstract()) {
                 return false;
             }
-            
+
             $entity = $reflClass->newInstanceWithoutConstructor();
         }
 
@@ -429,6 +441,10 @@ class Indexer
 
         $index = self::$indexSettings[$class]->getIndex();
         $indexName = $index->getAlgoliaName();
+
+        if (!empty($this->indexNamePrefix)) {
+            $indexName = $this->indexNamePrefix . '_' . $indexName;
+        }
 
         if ($index->getPerEnvironment() && $this->environment) {
             $indexName .= '_'.$this->environment;

--- a/README.md
+++ b/README.md
@@ -71,12 +71,15 @@ algolia:
     api_key: YOUR_API_KEY
 ```
 
-There's an extra parameter you can add to this file:
+There's two optional parameters you can add to this file:
 ```yaml
 algolia:
     catch_log_exceptions: true
+    index_name_prefix: staging
 ```
-To catch exceptions thrown in the doctrine event subscriber and log them.
+* **catch_log_exceptions**: If set to true, all exceptions thrown in the doctrine event subscriber will be caught and logged.
+* **index_name_prefix**: If set, this will add a prefix to all the index names (Useful if you want to setup multiple environments within the same Algolia app)
+
 
 # Mapping entities to Algolia indexes
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,6 +7,7 @@ services:
         class: %algolia.indexer.class%
         calls:
             - [setEnvironment, ["%kernel.environment%"]]
+            - [setIndexNamePrefix, ["%algolia.index_name_prefix%"]]
             - [setApiSettings, ["%algolia.application_id%", "%algolia.api_key%"]]
     algolia.indexer_subscriber:
         class: %algolia.indexer_subscriber.class%


### PR DESCRIPTION
I was looking for a way to configure several environments in the same Algolia app and noticed this wasn't possible in the current state of the bundle. I added a way to configure a prefix for the index table names.
This would allow the user to add a "prod_" or "staging_" prefix on any index name.

This should not introduce any BC break as the parameter is optional.

What do you think of this ?