### PR TITLE
Apply PSR-2 fixes

### DIFF
--- a/Command/SettingsCommand.php
+++ b/Command/SettingsCommand.php
@@ -65,7 +65,6 @@ class SettingsCommand extends ContainerAwareCommand
         $dirty = [];
 
         foreach ($localIndexSettings as $indexName => $localSettings) {
-
             if (empty($localSettings)) {
                 // Cannot update settings if they're empty.
                 continue;
@@ -73,8 +72,7 @@ class SettingsCommand extends ContainerAwareCommand
 
             try {
                 $currentSettings = $indexer->getIndex($indexName)->getSettings();
-            }
-            catch(\Exception $e) {
+            } catch (\Exception $e) {
                 $currentSettings = null;
             }
 

--- a/DependencyInjection/AlgoliaAlgoliaSearchExtension.php
+++ b/DependencyInjection/AlgoliaAlgoliaSearchExtension.php
@@ -22,19 +22,19 @@ class AlgoliaAlgoliaSearchExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (isset($config['application_id']))
+        if (isset($config['application_id'])) {
             $container->setParameter('algolia.application_id', $config['application_id']);
+        }
 
-        if (isset($config['api_key']))
+        if (isset($config['api_key'])) {
             $container->setParameter('algolia.api_key', $config['api_key']);
+        }
 
         $container->setParameter('algolia.catch_log_exceptions', $config['catch_log_exceptions']);
         $container->setParameter('algolia.index_name_prefix', $config['index_name_prefix']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
-
-
     }
 
     public function getAlias()

--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -306,17 +306,14 @@ class Indexer
         $accessor = PropertyAccess::createPropertyAccessor();
         $value = $accessor->getValue($entity, $field);
 
-        if ($value instanceof \Doctrine\Common\Collections\Collection)
-        {
-            if ($depth >= 2)
-            {
+        if ($value instanceof \Doctrine\Common\Collections\Collection) {
+            if ($depth >= 2) {
                 return null;
             }
 
             $value = $value->toArray();
 
-            if (count($value) > 0)
-            {
+            if (count($value) > 0) {
                 if (! $this->discoverEntity(reset($value), $this->em)) {
                     throw new NotAnAlgoliaEntity(
                         'Tried to index `'.$field.'` relation which is a `'.get_class(reset($value)).'` instance, which is not recognized as an entity to index.'
@@ -329,10 +326,8 @@ class Indexer
             }, $value);
         }
 
-        if (is_object($value) && $this->isEntity($this->em, $value))
-        {
-            if ($depth >= 2)
-            {
+        if (is_object($value) && $this->isEntity($this->em, $value)) {
+            if ($depth >= 2) {
                 return null;
             }
 
@@ -481,7 +476,6 @@ class Indexer
         $deletions = array();
 
         foreach ($this->entitiesScheduledForCreation as $entity) {
-
             if (is_object($entity)) {
                 $index = $this->getAlgoliaIndexName($entity);
             } else {
@@ -502,7 +496,6 @@ class Indexer
         }
 
         foreach ($this->entitiesScheduledForUpdate as $data) {
-
             $index = $this->getAlgoliaIndexName($data['entity']);
 
             list($primaryKey, $oldPrimaryKey) = $this->getPrimaryKeyForAlgolia($data['entity'], $data['changeSet']);
@@ -535,7 +528,6 @@ class Indexer
         }
 
         foreach ($this->entitiesScheduledForDeletion as $data) {
-
             $index = $data['index'];
 
             if (!isset($deletions[$index])) {

--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -132,7 +132,7 @@ class Indexer
         return str_replace("Proxies\\__CG__\\", "", $class);
     }
 
-    private function get_class($entity)
+    private function getClass($entity)
     {
         $class = get_class($entity);
 
@@ -155,7 +155,7 @@ class Indexer
     {
         if (is_object($entity_or_class)) {
             $entity = $entity_or_class;
-            $class = $this->get_class($entity);
+            $class = $this->getClass($entity);
             $class = $this->removeProxy($class);
         } else {
             $class = $em->getRepository($entity_or_class)->getClassName();
@@ -189,7 +189,7 @@ class Indexer
         if (!$this->discoverEntity($entity, $em)) {
             return false;
         } else {
-            return self::$indexSettings[$this->get_class($entity)]->getIndex()->getAutoIndex();
+            return self::$indexSettings[$this->getClass($entity)]->getIndex()->getAutoIndex();
         }
     }
 
@@ -201,7 +201,7 @@ class Indexer
      */
     private function shouldIndex($entity, array $changeSet = null)
     {
-        $class = $this->get_class($entity);
+        $class = $this->getClass($entity);
 
         $needsIndexing = true;
         $wasIndexed = true;
@@ -229,7 +229,7 @@ class Indexer
      */
     private function shouldHaveBeenIndexed($entity, array $originalData)
     {
-        foreach (self::$indexSettings[$this->get_class($entity)]->getIndexIfs() as $if) {
+        foreach (self::$indexSettings[$this->getClass($entity)]->getIndexIfs() as $if) {
             if (!$if->evaluateWith($entity, $originalData)) {
                 return false;
             }
@@ -353,7 +353,7 @@ class Indexer
      */
     public function getPrimaryKeyForAlgolia($entity, array $changeSet = null, $depth = 0)
     {
-        $class = $this->get_class($entity);
+        $class = $this->getClass($entity);
         if (!isset(self::$indexSettings[$class])) {
             throw new UnknownEntity("Entity `$class` is not known to Algolia. This is likely an implementation bug.");
         }
@@ -420,7 +420,7 @@ class Indexer
      */
     public function getFieldsForAlgolia($entity, array $changeSet = null, $depth = 0)
     {
-        $class = $this->get_class($entity);
+        $class = $this->getClass($entity);
 
         if (!isset(self::$indexSettings[$class])) {
             throw new UnknownEntity("Entity of class `$class` is not known to Algolia. This is likely an implementation bug.");
@@ -446,7 +446,7 @@ class Indexer
      */
     public function getAlgoliaIndexName($entity_or_class)
     {
-        $class = is_object($entity_or_class) ? $this->get_class($entity_or_class) : $entity_or_class;
+        $class = is_object($entity_or_class) ? $this->getClass($entity_or_class) : $entity_or_class;
 
         if (!isset(self::$indexSettings[$class])) {
             throw new UnknownEntity("Entity $class is not known to Algolia. This is likely an implementation bug.");

--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -290,7 +290,7 @@ class Indexer
     }
 
 
-    function isEntity(EntityManager $em, $class)
+    private function isEntity(EntityManager $em, $class)
     {
         if (is_object($class)) {
             $class = ($class instanceof Proxy)

--- a/Indexer/ManualIndexer.php
+++ b/Indexer/ManualIndexer.php
@@ -29,7 +29,6 @@ class ManualIndexer
     private function doIndex(array $entities, $indexName = null)
     {
         foreach ($entities as $entity) {
-
             if (!$this->indexer->discoverEntity($entity, $this->entityManager)) {
                 throw new NotAnAlgoliaEntity(
                     'Tried to index entity of class `'.get_class($entity).'`, which is not recognized as an entity to index.'
@@ -52,7 +51,6 @@ class ManualIndexer
     private function doUnIndex($entities)
     {
         foreach ($entities as $entity) {
-
             if (!$this->indexer->discoverEntity($entity, $this->entityManager)) {
                 throw new NotAnAlgoliaEntity(
                     'Tried to unIndex entity of class `'.get_class($entity).'`, which is not recognized as an entity to index.'

--- a/Mapping/Annotation/Attribute.php
+++ b/Mapping/Annotation/Attribute.php
@@ -9,7 +9,7 @@ namespace Algolia\AlgoliaSearchBundle\Mapping\Annotation;
 class Attribute
 {
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $algoliaName;
 }

--- a/Mapping/Annotation/Index.php
+++ b/Mapping/Annotation/Index.php
@@ -9,118 +9,118 @@ namespace Algolia\AlgoliaSearchBundle\Mapping\Annotation;
 class Index
 {
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $algoliaName;
 
     /**
-	 * @var  boolean
-	 */
+     * @var  boolean
+     */
     public $perEnvironment = true;
 
     /**
-	 * @var  boolean
-	 */
+     * @var  boolean
+     */
     public $autoIndex = true;
 
     /**
-	 * @var  integer
-	 */
+     * @var  integer
+     */
     public $minWordSizefor1Typo;
 
     /**
-	 * @var  integer
-	 */
+     * @var  integer
+     */
     public $minWordSizefor2Typos;
 
     /**
-	 * @var  integer
-	 */
+     * @var  integer
+     */
     public $hitsPerPage;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $attributesToIndex;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $attributesToRetrieve;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $unretrievableAttributes;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $optionalWords;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $attributesForFaceting;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $attributesToSnippet;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $attributesToHighlight;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $attributeForDistinct;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $ranking;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $slaves;
 
     /**
-	 * @var  array<string>
-	 */
+     * @var  array<string>
+     */
     public $customRanking;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $separatorsToIndex;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $removeWordsIfNoResults;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $queryType;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $highlightPreTag;
 
     /**
-	 * @var  string
-	 */
+     * @var  string
+     */
     public $highlightPostTag;
     
     /**
-	 * @var  array
-	 */
+     * @var  array
+     */
     public $synonyms;
 
     public function toArray()

--- a/Mapping/Helper/ChangeAwareMethod.php
+++ b/Mapping/Helper/ChangeAwareMethod.php
@@ -19,15 +19,15 @@ class ChangeAwareMethod
     }
 
     /**
-	 * This function violates all OOP design practices
-	 * by setting private properties of an external object.
-	 *
-	 * Well done, PHP :) http://php.net/manual/fr/closure.bind.php
-	 *
-	 * But we need this, as we can't assume there are setters on all fields.
-	 * And this is far more efficient than using a ReflectionClass:
-	 * http://ocramius.github.io/blog/accessing-private-php-class-members-without-reflection/
-	 */
+     * This function violates all OOP design practices
+     * by setting private properties of an external object.
+     *
+     * Well done, PHP :) http://php.net/manual/fr/closure.bind.php
+     *
+     * But we need this, as we can't assume there are setters on all fields.
+     * And this is far more efficient than using a ReflectionClass:
+     * http://ocramius.github.io/blog/accessing-private-php-class-members-without-reflection/
+     */
     private function fillWith($entity, array $data)
     {
         $privateSetter = \Closure::bind(function () use ($data) {

--- a/Mapping/Index.php
+++ b/Mapping/Index.php
@@ -80,9 +80,9 @@ class Index
     }
 
     /**
-	 * Returns the index settings in a format
-	 * compatible with that expected by https://github.com/algolia/algoliasearch-client-php
-	 */
+     * Returns the index settings in a format
+     * compatible with that expected by https://github.com/algolia/algoliasearch-client-php
+     */
     public function getAlgoliaSettings()
     {
         $settings = [];

--- a/Mapping/Loader/AnnotationLoader.php
+++ b/Mapping/Loader/AnnotationLoader.php
@@ -114,7 +114,6 @@ class AnnotationLoader implements LoaderInterface
         }
 
         if (!$description->isEmpty()) {
-
             $meta = $em->getClassMetadata($class);
             if (!$description->hasIdentifierFieldNames()) {
                 $description->setIdentifierAttributeNames($meta->getIdentifierFieldNames());
@@ -128,10 +127,8 @@ class AnnotationLoader implements LoaderInterface
             }
 
             return $description;
-
         } else {
             return false;
-
         }
     }
 }

--- a/Mapping/Loader/LoaderInterface.php
+++ b/Mapping/Loader/LoaderInterface.php
@@ -7,9 +7,9 @@ use Doctrine\ORM\EntityManager;
 interface LoaderInterface
 {
     /**
-	 * Extracts the Algolia metaData from an entity.
-	 *
-	 * @return Algolia\AlgoliaSearchBundle\Mapping\Description
-	 */
+     * Extracts the Algolia metaData from an entity.
+     *
+     * @return Algolia\AlgoliaSearchBundle\Mapping\Description
+     */
     public function getMetaData($entity, EntityManager $em);
 }

--- a/Tests/AlgoliaSearch/ChangeDetectionTest.php
+++ b/Tests/AlgoliaSearch/ChangeDetectionTest.php
@@ -165,11 +165,11 @@ class ChangeDetectionTest extends BaseTest
     {
         /**
          * This one is a bit special:
-         * 
+         *
          * If a product has a composite primary key, updating a field from the primary key
          * will actually be equivalent to deleting the product and inserting a new one, which
          * will have a different objectID.
-         * 
+         *
          * So in this case, what should happen is:
          * - old product is unindexed from Algolia
          * - updated product is inserted into Algolia index as a new entity

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -14,7 +14,6 @@ class AppKernel extends Kernel
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
-
         }
 
         return $bundles;

--- a/Tests/BaseTest.php
+++ b/Tests/BaseTest.php
@@ -34,7 +34,6 @@ class BaseTest extends \PHPUnit_Framework_TestCase
             }
 
             if (preg_match('/\.php$/', $entry)) {
-
                 if (!empty(static::$neededEntityTypes) && !in_array(basename($entry, '.php'), static::$neededEntityTypes)) {
                     continue;
                 }

--- a/Tests/Entity/BaseTestAwareEntity.php
+++ b/Tests/Entity/BaseTestAwareEntity.php
@@ -15,8 +15,10 @@ class BaseTestAwareEntity
 
     public function getTestProp($prop, $default = null)
     {
-        if (isset($this->test_props[$prop]))
+        if (isset($this->test_props[$prop])) {
             return $this->test_props[$prop];
-        else return $default;
+        } else {
+            return $default;
+        }
     }
 }

--- a/Tests/Entity/ProductWithCustomAttributeNames.php
+++ b/Tests/Entity/ProductWithCustomAttributeNames.php
@@ -26,7 +26,7 @@ class ProductWithCustomAttributeNames extends BaseTestAwareEntity
      * @var string
      *
      * @ORM\Column(name="name", type="string", length=255)
-     * 
+     *
      * @Algolia\Attribute(algoliaName="nonDefaultAttributeName")
      */
     protected $name;

--- a/Tests/Indexer/Indexer.php
+++ b/Tests/Indexer/Indexer.php
@@ -65,7 +65,6 @@ class Indexer extends \Algolia\AlgoliaSearchBundle\Indexer\Indexer
                 $application_id = getenv('ALGOLIA_APPLICATION_ID');
                 $api_key = getenv('ALGOLIA_API_KEY');
             }
-
         } catch (\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException $e) {
             // ignore this, it means we're just not running on Travis
         }

--- a/Tests/phpunit.xml
+++ b/Tests/phpunit.xml
@@ -1,14 +1,14 @@
 <phpunit bootstrap="./app.php">
-	<testsuites>
-		<testsuite name="AlgoliaSearch">
-			<file>./AlgoliaSearch/EntityAliasTest.php</file>
-			<file>./AlgoliaSearch/CallbacksTest.php</file>
-			<file>./AlgoliaSearch/ChangeDetectionTest.php</file>
-			<file>./AlgoliaSearch/ManualIndexingTest.php</file>
-			<file>./AlgoliaSearch/ConditionalIndexingTest.php</file>
-			<file>./AlgoliaSearch/AlgoliaIntegrationTest.php</file>
-			<file>./AlgoliaSearch/ReindexCommandTest.php</file>
-			<file>./AlgoliaSearch/SettingsCommandTest.php</file>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="AlgoliaSearch">
+            <file>./AlgoliaSearch/EntityAliasTest.php</file>
+            <file>./AlgoliaSearch/CallbacksTest.php</file>
+            <file>./AlgoliaSearch/ChangeDetectionTest.php</file>
+            <file>./AlgoliaSearch/ManualIndexingTest.php</file>
+            <file>./AlgoliaSearch/ConditionalIndexingTest.php</file>
+            <file>./AlgoliaSearch/AlgoliaIntegrationTest.php</file>
+            <file>./AlgoliaSearch/ReindexCommandTest.php</file>
+            <file>./AlgoliaSearch/SettingsCommandTest.php</file>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "symfony/framework-bundle": "~2.5|~3.0",
         "symfony/finder": "~2.5|~3.0",
-	"symfony/property-access": "~2.5|~3.0",
+        "symfony/property-access": "~2.5|~3.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "algolia/algoliasearch-client-php": "~1.6"


### PR DESCRIPTION
This PR applies the PSR-2 standard consistently throughout the codebase. Among the fixes:
* Replace all tabs with spaces
* Apply automatic fixes from phpcbf
* Use camelCase for methods (affects `Indexer::get_class`)
* Add visibility to `Indexer::isEntity`: this method had no visibility set. Since it was only being used within `Indexer`, I applied `private` to it even though it is technically a BC break. I don't think that method should be part of the public API.