### PR TITLE
Deprecate old PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-    - 5.4
-    - 5.5
+    - 5.6
+    - 7.0
 before_install: curl -sS https://getcomposer.org/installer | php
 install: php composer.phar install
 before_script: mv Tests/config/parameters.yml.travis Tests/config/parameters.yml

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "description": "Seamless integration of Algolia Search into your Symfony project.",
     "license": "MIT",
     "require": {
+        "php": "^5.6 || ^7.0",
         "symfony/framework-bundle": "~2.5|~3.0",
         "symfony/finder": "~2.5|~3.0",
 	"symfony/property-access": "~2.5|~3.0",


### PR DESCRIPTION
`composer.json` didn't specify a minimum PHP version, which it absolutely should. Since PHP 5.5 and older are no longer being supported, I think the requirement for 5.6 and up should be ok. `.travis.yml` has been adapter to run tests on these two platforms as well.