### PR TITLE
When applied, this commit will add specifically loading mechanisms to be able to implement YAML/XML loaders

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearchBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -18,22 +19,41 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('algolia');
-        $rootNode->children()
-            ->scalarNode('application_id')
-            ->end()
-            ->scalarNode('api_key')
-            ->end()
-            ->scalarNode('index_name_prefix')
-            ->defaultValue('')
-            ->end()
-            ->booleanNode('catch_log_exceptions')
-              ->defaultFalse()
-            ->end();
+        $rootNode = $treeBuilder
+            ->root('algolia', 'array')
+                ->children()
+                    ->scalarNode('application_id')->end()
+                    ->scalarNode('api_key')->end()
+                    ->scalarNode('index_name_prefix')->defaultValue('')->end()
+                    ->booleanNode('catch_log_exceptions')->defaultFalse()->end()
+        ;
+
+        $this->addMetadataSection($rootNode);
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.
         return $treeBuilder;
+    }
+
+    private function addMetadataSection(NodeBuilder $builder)
+    {
+        $builder
+            ->arrayNode('metadata')
+                ->addDefaultsIfNotSet()
+                ->fixXmlConfig('directory', 'directories')
+                ->children()
+                    ->booleanNode('auto_detection')->defaultFalse()->end()
+                    ->arrayNode('directories')
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('path')->isRequired()->end()
+                                ->scalarNode('namespace_prefix')->defaultValue('')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 }

--- a/Mapping/Loader/AbstractFileLoader.php
+++ b/Mapping/Loader/AbstractFileLoader.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
+
+use Doctrine\ORM\EntityManager;
+
+abstract class AbstractFileLoader implements LoaderInterface
+{
+    /**
+     * @var FileLocatorInterface|FileLocator
+     */
+    private $locator;
+
+    public function __construct(FileLocatorInterface $locator)
+    {
+        $this->locator = $locator;
+    }
+
+    public function getMetaData($entity, EntityManager $em)
+    {
+        $class = new \ReflectionClass($entity);
+        if (null === $path = $this->locator->findFileForClass($class, $this->getExtension())) {
+            return null;
+        }
+
+        return $this->loadMetadataFromFile($class, $path);
+    }
+
+    /**
+     * Parses the content of the file, and converts it to the desired metadata.
+     *
+     * @param \ReflectionClass $class
+     * @param string           $file
+     */
+    abstract protected function loadMetadataFromFile(\ReflectionClass $class, $file);
+
+    /**
+     * Returns the extension of the file.
+     *
+     * @return string
+     */
+    abstract protected function getExtension();
+}

--- a/Mapping/Loader/FileLocator.php
+++ b/Mapping/Loader/FileLocator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
+
+class FileLocator implements FileLocatorInterface
+{
+    private $dirs;
+
+    public function __construct(array $dirs)
+    {
+        $this->dirs = $dirs;
+    }
+
+    public function getDirs()
+    {
+        return $this->dirs;
+    }
+
+    /**
+     * @param \ReflectionClass $class
+     * @param string           $extension
+     *
+     * @return string|null
+     */
+    public function findFileForClass(\ReflectionClass $class, $extension)
+    {
+        foreach ($this->dirs as $prefix => $dir) {
+            if ('' !== $prefix && 0 !== strpos($class->getNamespaceName(), $prefix)) {
+                continue;
+            }
+
+            $len = '' === $prefix ? 0 : strlen($prefix) + 1;
+            $path = $dir.'/'.str_replace('\\', '.', substr($class->name, $len)).'.'.$extension;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Mapping/Loader/FileLocatorInterface.php
+++ b/Mapping/Loader/FileLocatorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
+
+interface FileLocatorInterface
+{
+    /**
+     * @param \ReflectionClass $class
+     * @param string           $extension
+     *
+     * @return string|null
+     */
+    public function findFileForClass(\ReflectionClass $class, $extension);
+}

--- a/Mapping/Loader/LoaderChain.php
+++ b/Mapping/Loader/LoaderChain.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
+
+use Doctrine\ORM\EntityManager;
+
+final class LoaderChain implements LoaderInterface
+{
+    private $loaders;
+
+    public function getMetaData($entity, EntityManager $em)
+    {
+        foreach ($this->loaders as $loader) {
+            if (null !== $metadata = $loader->getMetaData($entity, $em)) {
+                return $metadata;
+            }
+        }
+
+        return null;
+    }
+
+    public function __construct(array $loaders = array())
+    {
+        $this->loaders = $loaders;
+    }
+
+    public function addLoader(LoaderInterface $loader)
+    {
+        $this->loaders[] = $loader;
+    }
+}

--- a/Mapping/Loader/YamlLoader.php
+++ b/Mapping/Loader/YamlLoader.php
@@ -2,6 +2,11 @@
 
 namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
 
+use Algolia\AlgoliaSearchBundle\Mapping\Description;
+use Algolia\AlgoliaSearchBundle\Mapping\Index;
+use Algolia\AlgoliaSearchBundle\Mapping\IndexIf;
+use Algolia\AlgoliaSearchBundle\Mapping\Method;
+use Algolia\AlgoliaSearchBundle\Mapping\Property;
 use Symfony\Component\Yaml\Yaml;
 
 class YamlLoader extends AbstractFileLoader
@@ -10,11 +15,149 @@ class YamlLoader extends AbstractFileLoader
     {
         $config = Yaml::parse(file_get_contents($file));
 
-        if ( ! isset($config[$name = $class->name])) {
+        if (!isset($config[$name = $class->name])) {
             throw new \RuntimeException(sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
         }
 
-        return null;
+        $config = $config[$name];
+        $className = $this->removeProxy($name);
+        $description = new Description($class);
+
+        $this->extractClassMetadatas($config, $className, $description);
+
+        $this->extractPropertyMetadata($class, $className, $config, $description);
+
+        $this->extractMethodMetadata($class, $className, $config, $description);
+
+        return $description;
+    }
+
+    /**
+     * @param $config
+     * @param $className
+     * @param $description
+     */
+    protected function extractClassMetadatas($config, $className, Description $description)
+    {
+        $classMetadata = [];
+
+        $classMetadata['perEnvironment'] = true;
+        if (isset($config['perEnvironment'])) {
+            $classMetadata['perEnvironment'] = $config['perEnvironment'];
+        }
+
+        $classMetadata['autoIndex'] = true;
+        if (isset($config['autoIndex'])) {
+            $classMetadata['autoIndex'] = $config['autoIndex'];
+        }
+
+        if (isset($config['algoliaName'])) {
+            $classMetadata['algoliaName'] = $config['algoliaName'];
+        }
+
+        foreach (Index::$algoliaSettingsProps as $field) {
+            if (isset($config[$field])) {
+                $classMetadata[$field] = $config[$field];
+            }
+        }
+
+        $index = new Index();
+        $index->setAlgoliaNameFromClass($className);
+        $index->updateSettingsFromArray($classMetadata);
+        $description->setIndex($index);
+    }
+
+    /**
+     * @param \ReflectionClass $class
+     * @param $className
+     * @param $config
+     * @param $description
+     */
+    protected function extractPropertyMetadata(\ReflectionClass $class, $className, $config, Description $description)
+    {
+        foreach ($class->getProperties() as $property) {
+            if ($className !== $property->class) {
+                continue;
+            }
+
+            $propertyName = $property->getName();
+
+            if (isset($config['properties'][$propertyName])) {
+                $propertyConfig = $config['properties'][$propertyName];
+
+                if (!isset($propertyConfig['type']) && !is_scalar($propertyConfig['type'])) {
+                    throw new \RuntimeException('The "type" attribute must be set for each property.');
+                }
+
+                if ((string) $propertyConfig['type'] === 'attribute') {
+                    $field = new Property();
+                    $field->setName($property->getName());
+
+                    if (isset($propertyConfig['algoliaName'])) {
+                        $field->setAlgoliaName($propertyConfig['algoliaName']);
+                    } else {
+                        $field->setAlgoliaName($field->getName());
+                    }
+
+                    $description->addProperty($field);
+                } elseif ((string) $propertyConfig['type'] === 'id') {
+                    $description->addIdentifierAttributeName($propertyName);
+                } else {
+                    throw new \RuntimeException('The "type" attribute is wrongly configured.');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \ReflectionClass $class
+     * @param $className
+     * @param $config
+     * @param $description
+     */
+    protected function extractMethodMetadata(\ReflectionClass $class, $className, $config, Description $description)
+    {
+        foreach ($class->getMethods() as $method) {
+            if ($className !== $method->class) {
+                continue;
+            }
+
+            $methodName = $method->getName();
+
+            if (isset($config['methods'][$methodName])) {
+                $methodConfig = $config['methods'][$methodName];
+
+                if (!isset($methodConfig['type']) && !is_scalar($methodConfig['type'])) {
+                    throw new \RuntimeException('The "type" attribute must be set for each methods.');
+                }
+
+                if ((string) $methodConfig['type'] === 'attribute') {
+                    $field = new Method();
+                    $field->setName($methodName);
+
+                    if (isset($methodConfig['algoliaName'])) {
+                        $field->setAlgoliaName($methodConfig['algoliaName']);
+                    } else {
+                        $field->setAlgoliaName(lcfirst(preg_replace('/^get([A-Z])/', '$1', $field->getName())));
+                    }
+
+                    $description->addMethod($field);
+                } elseif ((string) $methodConfig['type'] === 'indexIf') {
+                    $indexIf = new IndexIf();
+                    $indexIf->setName($methodName);
+
+                    $description->addIndexIf($indexIf);
+                } else {
+                    throw new \RuntimeException('The "type" attribute is wrongly configured on.');
+                }
+            }
+        }
+    }
+
+    private function removeProxy($class)
+    {
+        /* Avoid proxy class form symfony */
+        return str_replace('Proxies\\__CG__\\', '', $class);
     }
 
     protected function getExtension()

--- a/Mapping/Loader/YamlLoader.php
+++ b/Mapping/Loader/YamlLoader.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Mapping\Loader;
+
+use Symfony\Component\Yaml\Yaml;
+
+class YamlLoader extends AbstractFileLoader
+{
+    protected function loadMetadataFromFile(\ReflectionClass $class, $file)
+    {
+        $config = Yaml::parse(file_get_contents($file));
+
+        if ( ! isset($config[$name = $class->name])) {
+            throw new \RuntimeException(sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
+        }
+
+        return null;
+    }
+
+    protected function getExtension()
+    {
+        return 'yml';
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,10 +1,16 @@
 parameters:
     algolia.indexer.class: Algolia\AlgoliaSearchBundle\Indexer\Indexer
     algolia.indexer_subscriber.class: Algolia\AlgoliaSearchBundle\EventListener\AlgoliaSearchDoctrineEventSubscriber
+    algolia.metadata.file_locator.class: Algolia\AlgoliaSearchBundle\Mapping\Loader\FileLocator
+    algolia.metadata.chain_loader.class: Algolia\AlgoliaSearchBundle\Mapping\Loader\LoaderChain
+    algolia.metadata.annotation_loader.class: Algolia\AlgoliaSearchBundle\Mapping\Loader\AnnotationLoader
+    algolia.metadata.yaml_loader.class: Algolia\AlgoliaSearchBundle\Mapping\Loader\YamlLoader
 
 services:
     algolia.indexer:
         class: "%algolia.indexer.class%"
+        arguments:
+            - "@algolia.metadata.chain_loader"
         calls:
             - [setEnvironment, ["%kernel.environment%"]]
             - [setIndexNamePrefix, ["%algolia.index_name_prefix%"]]
@@ -17,3 +23,21 @@ services:
             - "@?logger"
         tags:
             - {name: doctrine.event_subscriber}
+    algolia.metadata.file_locator:
+        public: false
+        class: "%algolia.metadata.file_locator.class%"
+        arguments:
+            - []
+    algolia.metadata.annotation_loader:
+        class: "%algolia.metadata.annotation_loader.class%"
+    algolia.metadata.chain_loader:
+        public: false
+        class: "%algolia.metadata.chain_loader.class%"
+        arguments:
+            - [ "@algolia.metadata.yaml_loader", "@algolia.metadata.annotation_loader" ]
+    algolia.metadata.yaml_loader:
+        public: false
+        class: "%algolia.metadata.yaml_loader.class%"
+        arguments:
+            - "@algolia.metadata.file_locator"
+


### PR DESCRIPTION
#### Summary :

This patch introduce a new loading system in order to be able to create mapping configuration other than Annotation such as Yaml/XML.
It makes it possible to use both XML/YAML/Annotations in the same projects for different bundles.
It has greatly been inspired by loading mechanism used in JMS/Serializer and the Validator component of Symfony.
Feedbacks are really welcomed.
#### Status :
- Loading mechanism working
- No tests (I really did not understand test structuration in the bundle, need help)
- YamlLoader (the one that interest us is not yes implemented, coming soon)
- Maybe rewrite it by extending JMS/Metadata (not enough time right now)
#### How does it work ? :
1. `AlgoliaAlgoliaSearchExtension` loads all bundles (or the one you specify under `metadata>directories` and looks for configuration in `Resources/config/indexer` by default
2. It then injects mapped directories in a `FileLoactor`which roles is to retrieve a conf. files yml/xml from a class.
3. On every flush made by doctrine, the indexer now called a `LoaderChain` with iterates over all configured Loaders starting by file loaders (yml/xml).
4. Once the right loader has been found, it simply builds metadatas.

This work (still in progress) has been brought to the community by [My Little Paris Tech Team](https://github.com/MyLittleParis)
