### PR TITLE
Allow skipping non Algolia entities in commands

### DIFF
--- a/Indexer/ManualIndexer.php
+++ b/Indexer/ManualIndexer.php
@@ -191,7 +191,7 @@ class ManualIndexer
 
         if (!$this->indexer->discoverEntity($className, $this->entityManager)) {
             throw new NotAnAlgoliaEntity(
-                'Tried to index entity of class `'.get_class($className).'`, which is not recognized as an entity to index.'
+                'Tried to clear index for entity of class `'.$className.'`, which is not recognized as an entity to index.'
             );
         }
 
@@ -230,7 +230,7 @@ class ManualIndexer
 
         if (!$this->indexer->discoverEntity($className, $this->entityManager)) {
             throw new NotAnAlgoliaEntity(
-                'Tried to index entity of class `'.$className.'`, which is not recognized as an entity to index.'
+                'Tried to reindex entity of class `'.$className.'`, which is not recognized as an entity to index.'
             );
         }
 


### PR DESCRIPTION
When invoking the clear or reindex command for all known entities the command will fail if at least one entity is not Algolia mapped. This is inkonsistent regarding the settings command and makes it
difficult in automation processes.

By adding a new optional command line settings this kind of error can be skipped. By default the command behavior is not changing (BC).
