### PR TITLE
Prevent removal of embedded documents

### DIFF
--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -277,6 +277,10 @@ class Indexer
             return;
         }
 
+        if ($this->isEmbeddedObject($entity)) {
+            return;
+        }
+
         // We need to get the primary key now, because post-flush it will be gone from the entity
         list($primaryKey, $unusedOldPrimaryKey) = $this->getPrimaryKeyForAlgolia($entity);
         $this->entitiesScheduledForDeletion[] = array(

--- a/Tests/AlgoliaSearch/ODM/EmbeddedDocumentTest.php
+++ b/Tests/AlgoliaSearch/ODM/EmbeddedDocumentTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ODM;
+
+use Algolia\AlgoliaSearchBundle\Tests\BaseTest;
+use Algolia\AlgoliaSearchBundle\Tests\Entity\ProductWithEmbeddedDocument;
+use Algolia\AlgoliaSearchBundle\Tests\Traits\ODMTestTrait;
+
+class EmbeddedDocumentTest extends BaseTest
+{
+    use ODMTestTrait;
+
+    public function beforeEach()
+    {
+        $this->getIndexer()->reset();
+    }
+
+    public function testPersistingProductOnlyTriggersOneCreation()
+    {
+        $product = new ProductWithEmbeddedDocument();
+        $product
+            ->setName('The Ultimate Algolia Userguide')
+            ->setShortDescription('Learn to master your search engine and drive sales up!')
+            ->setRating(1);
+
+        $this->persistAndFlush($product);
+        $this->assertCount(1, $this->getIndexer()->creations);
+
+        return $product;
+    }
+
+    public function testUpdatingProductOnlyTriggersOneUpdate()
+    {
+        $product = new ProductWithEmbeddedDocument();
+        $product
+            ->setName('The Ultimate Algolia Userguide')
+            ->setShortDescription('Learn to master your search engine and drive sales up!')
+            ->setRating(1);
+
+        $this->persistAndFlush($product);
+        $this->getIndexer()->reset();
+
+        $product
+            ->setName('The Ultimate Guide')
+            ->setRating(2);
+
+        $this->persistAndFlush($product);
+        $this->assertCount(1, $this->getIndexer()->updates);
+
+        return $product;
+    }
+
+    public function testDeletingProductOnlyTriggersOneDeletion()
+    {
+        $product = new ProductWithEmbeddedDocument();
+        $product
+            ->setName('The Ultimate Algolia Userguide')
+            ->setShortDescription('Learn to master your search engine and drive sales up!')
+            ->setRating(1);
+
+        $this->persistAndFlush($product);
+        $this->getIndexer()->reset();
+
+        $this->removeAndFlush($product);
+
+        $this->assertCount(1, $this->getIndexer()->deletions);
+
+        return $product;
+    }
+}

--- a/Tests/Entity/EmbeddedDocument.php
+++ b/Tests/Entity/EmbeddedDocument.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\Entity;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbeddedDocument
+{
+    /**
+     * @var integer
+     *
+     * @ODM\Field(type="int")
+     *
+     * @Algolia\Attribute
+     */
+    protected $rating;
+
+    /**
+     * Set rating
+     *
+     * @param  integer $rating
+     * @return EmbeddedDocument
+     */
+    public function setRating($rating)
+    {
+        $this->rating = $rating;
+
+        return $this;
+    }
+
+    /**
+     * Get rating
+     *
+     * @return integer
+     */
+    public function getRating()
+    {
+        return $this->rating;
+    }
+}

--- a/Tests/Entity/ProductWithEmbeddedDocument.php
+++ b/Tests/Entity/ProductWithEmbeddedDocument.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\Entity;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+
+/**
+ * @ODM\Document
+ *
+ * @Algolia\Index
+ */
+class ProductWithEmbeddedDocument extends BaseTestAwareEntity
+{
+    /**
+     * @var integer
+     *
+     * @ODM\Id()
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="string")
+     *
+     * @Algolia\Attribute
+     */
+    protected $name;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="float")
+     *
+     * @Algolia\Attribute
+     */
+    protected $price;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="string")
+     *
+     * @Algolia\Attribute
+     */
+    protected $shortDescription;
+
+    /**
+     * @var string
+     *
+     * @ODM\Field(type="string")
+     *
+     * @Algolia\Attribute
+     */
+    protected $description;
+
+    /**
+     * @var EmbeddedDocument
+     *
+     * @ODM\EmbedOne(targetDocument=EmbeddedDocument::class)
+     *
+     * @Algolia\Attribute
+     */
+    protected $embed;
+
+    public function __construct()
+    {
+        $this->embed = new EmbeddedDocument();
+    }
+
+    /**
+     * Get id
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set name
+     *
+     * @param  string  $name
+     * @return ProductWithEmbeddedDocument
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @Algolia\Attribute
+     */
+    public function getYoName()
+    {
+        return 'YO ' . $this->getName();
+    }
+
+    /**
+     * Set price
+     *
+     * @param  string  $price
+     * @return ProductWithEmbeddedDocument
+     */
+    public function setPrice($price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * Get price
+     *
+     * @return string
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Set shortDescription
+     *
+     * @param  string  $shortDescription
+     * @return ProductWithEmbeddedDocument
+     */
+    public function setShortDescription($shortDescription)
+    {
+        $this->shortDescription = $shortDescription;
+
+        return $this;
+    }
+
+    /**
+     * Get shortDescription
+     *
+     * @return string
+     */
+    public function getShortDescription()
+    {
+        return $this->shortDescription;
+    }
+
+    /**
+     * Set description
+     *
+     * @param  string  $description
+     * @return ProductWithEmbeddedDocument
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Get description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set rating
+     *
+     * @param  integer $rating
+     * @return ProductWithEmbeddedDocument
+     */
+    public function setRating($rating)
+    {
+        $this->embed->setRating($rating);
+
+        return $this;
+    }
+
+    /**
+     * Get rating
+     *
+     * @return integer
+     */
+    public function getRating()
+    {
+        return $this->embed->getRating();
+    }
+
+    /**
+     * @return EmbeddedDocument
+     */
+    public function getEmbed()
+    {
+        return $this->embed;
+    }
+}

--- a/Tests/Traits/ORMTestTrait.php
+++ b/Tests/Traits/ORMTestTrait.php
@@ -32,9 +32,13 @@ trait ORMTestTrait
     {
         $em = static::staticGetObjectManager();
 
-        $schema = array_map(function ($class) use ($em) {
-            return $em->getClassMetadata($class);
-        }, static::getNeededEntities());
+        $schema = array_filter(array_map(function ($class) use ($em) {
+            try {
+                return $em->getClassMetadata($class);
+            } catch (\Exception $e) {
+                return false;
+            }
+        }, static::getNeededEntities()));
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema($schema);


### PR DESCRIPTION
This fixes a bug I introduced along with ODM support. Removing an entity that contains an embedded document will trigger a removal for that object as well, which then causes an error because embedded documents don't have an identifier.

The fix is simple; this PR also adds tests to ensure only one creation/update/deletion is triggered when writing documents that contain embed relationships.