### PR TITLE
Remove dependency to orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,6 @@
         "symfony/framework-bundle": "~2.8|~3.0",
         "symfony/property-access": "~3.2",
         "symfony/yaml": "^3.2",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "doctrine/doctrine-bundle": "~1.2",
         "algolia/algoliasearch-client-php": "~1.6"
     },
     "require-dev": {


### PR DESCRIPTION
I missed this when looking at #111. The ORM dependency is included in `require-dev` to avoid tightly coupling the bundle to ORM. With ORM and MongoDB ODM being supported it makes no sense to require one or the other since they won't be used without being explicitly enabled by the user.

This also avoids installing Doctrine ORM for projects using only MongoDB ODM.