### PR TITLE
Remove Algolia credentials from .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ php:
 
 env:
   global:
-      - secure: kVMG3//7KXQ6I8qOD1B0Nsb7b4lRJenbt6fVFYWr/u3V/pEHoWlmab4isCHh3sBi3Y5ArlAyprKvJwHYG4Y8C+LKGOFaJEYmKwyoftWHCaF4PR2KYs+5ScZwso84/RRHlD7mYMhdrLgJ2TtbeZoZclgJ85S1zETrYPrgfZpFm50=
-      - secure: A/Vsshcysra1lor07JeUZ6iYCP5Q26IqiEQI1fMq9kElIliHl4BntrIhjOeL/nvj2iUSJz1S+n1pnM5MDGSyHFXSGu/w2MJy+k1COPcp1/GRmuU2dTlcKVaDZ5xU4XkE+zKNpONAwfFUtYNhcUOCVqbOthusFTAavVv1d7WrFQ8=
       - DRIVER_VERSION="stable"
       - ADAPTER_VERSION="^1.0.0"
 


### PR DESCRIPTION
Credentials are now defined in the Travis admin.
